### PR TITLE
Api/add warning about requests to other apis

### DIFF
--- a/docs/how-to-guides/faststore-api/fetching-api-data.mdx
+++ b/docs/how-to-guides/faststore-api/fetching-api-data.mdx
@@ -5,6 +5,10 @@ import TabItem from '@theme/TabItem'
 
 You can build and customize GraphQL queries to display ecommerce data on your storefront, such as products and shopping cart information. In this guide, you will find the basic concepts and steps to implement this in your FastStore project.
 
+:::caution
+When building your storefront with FastStore, you must not send requests to APIs other than the FastStore API. If you need to access other data not available in the [native FastStore API schema](https://www.faststore.dev/reference/api/queries), you must do this by [extending the GraphQL schema](https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api). Otherwise, site performance may be compromised and lead to `504` timeout errors.
+:::
+
 ## Before you start
 
 Before getting to work on your code, there are some concepts you should be familiar with when it comes to the FastStore API.

--- a/docs/reference/api/faststore-api.md
+++ b/docs/reference/api/faststore-api.md
@@ -19,7 +19,7 @@ With the FastStore API, you can:
 Also, thanks to a type-safe **GraphQL** protocol, the FastStore API allows developers to fetch only the strongly typed data needed for building robust and responsive solutions. In practice, developers can source the FastStore API to the [**Next.js**](https://nextjs.org/) or [**Gatsby**](https://www.gatsbyjs.com/) data layers and consume it on frontend components to create stores that use the [**Jamstack**](https://jamstack.org/) architecture.
 
 :::caution
-When building your storefront with FastStore, you must not send requests to APIs other than the FastStore API. If you need to access other data not available in the [native FastStore API schema](https://www.faststore.dev/reference/api/queries), you must do this by [extending the GraphQL schema](https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api). Otherwise, site performance may be compromised and lead to `504` timeout errors.
+When building your storefront with FastStore, you must not send requests to APIs other than the FastStore API. If you need to access other data not available in the [native FastStore API schema](https://www.faststore.dev/reference/api/queries), you must do this by [extending the GraphQL schema](https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api). Otherwise, site performance may be compromised and lead to `504` timeout errors. 
 :::
 
 ![FastStore API usage architecture](https://vtexhelp.vtexassets.com/assets/docs/src/faststoreAPI2___58c4a9c4d23539900ef8b1cce9769288.png)

--- a/docs/reference/api/faststore-api.md
+++ b/docs/reference/api/faststore-api.md
@@ -18,6 +18,10 @@ With the FastStore API, you can:
 
 Also, thanks to a type-safe **GraphQL** protocol, the FastStore API allows developers to fetch only the strongly typed data needed for building robust and responsive solutions. In practice, developers can source the FastStore API to the [**Next.js**](https://nextjs.org/) or [**Gatsby**](https://www.gatsbyjs.com/) data layers and consume it on frontend components to create stores that use the [**Jamstack**](https://jamstack.org/) architecture.
 
+:::caution
+When building your storefront with FastStore, you must not send requests to APIs other than the FastStore API. If you need to access other data not available in the [native FastStore API schema](https://www.faststore.dev/reference/api/queries), you must do this by [extending the GraphQL schema](https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api). Otherwise, site performance may be compromised and lead to `504` timeout errors.
+:::
+
 ![FastStore API usage architecture](https://vtexhelp.vtexassets.com/assets/docs/src/faststoreAPI2___58c4a9c4d23539900ef8b1cce9769288.png)
 
 :::info


### PR DESCRIPTION
Adding warning about sending requests to other APIs to two guides:
- [FastStore API](https://www.faststore.dev/reference/api/faststore-api)
- [Fetching data](https://www.faststore.dev/how-to-guides/faststore-api/fetching-api-data)

The goal is to avoid other clients running into the issue that caused this [escalation](https://vtex.slack.com/archives/C017NPK8U86/p1674589717501439?thread_ts=1674033628.681769&cid=C017NPK8U86).