### PR TITLE
Fix: Update links in docs to use relative path

### DIFF
--- a/docs/conceptual-guides/analytics-on-official-starters.md
+++ b/docs/conceptual-guides/analytics-on-official-starters.md
@@ -1,21 +1,7 @@
 ---
 title: Analytics on official starters
 description: An overview of our analytics solutions implemented by our official starters and a brief comparison with Store Framework's approach to analytics.
-tags:
-  [
-    ga,
-    gtm,
-    google analytics,
-    google tag manager,
-    google,
-    analytics,
-    sdk,
-    faststore,
-    starters,
-    store framework,
-    AnalyticsHandler,
-    gtmContainerId,
-  ]
+tags: [ga, gtm, google analytics, google tag manager, google, analytics, sdk, faststore, starters, store framework, AnalyticsHandler, gtmContainerId]
 hide_table_of_contents: false
 ---
 
@@ -25,15 +11,15 @@ hide_table_of_contents: false
 We strongly recommend reading the [Analytics on FastStore](/conceptual-guides/analytics-on-faststore) article before diving into this article.
 :::
 
-The recommended way to start building with FastStore is with one of our official starters. They are functional store templates that adhere to web performance and accessibility best practices, also serving as a guideline for all developers building storefronts with FastStore. In this regard, all our official starters have built-in analytics capabilities.
+The recommended way to start building with FastStore is with one of our official starters. They are functional store templates that adhere to web performance and accessibility best practices, also serving as a guideline for all developers building storefronts with FastStore. In this regard, all our official starters have built-in analytics capabilities. 
 
-This article explains how these starters integrate with analytics features and other architectural aspects.
+This article explains how these starters integrate with analytics features and other architectural aspects. 
 
 ## Google Tag Manager
 
-Our official starters include built-in **Google Tag Manager (GTM)** scripts, so developers don't have to worry about manually implementing the GTM script to their website nor configuring debug query strings related to [Partytown](/how-to-guides/troubleshooting/analytics-and-partytown#google-tag-assistant-is-not-working).
+Our official starters include built-in **Google Tag Manager (GTM)** scripts, so developers don't have to worry about manually implementing the GTM script to their website nor configuring debug query strings related to [Partytown](/how-to-guides/troubleshooting/analytics-and-partytown#google-tag-assistant-is-not-working). 
 
-Our official starters come with two GTM scripts in the `src/components/ThirdPartyScripts/GoogleTagManager.tsx` component: one that runs inside Partytown if the `gtm_debug` query string is not present, and one that runs outside Partytown otherwise.
+Our official starters come with two GTM scripts in the `src/components/ThirdPartyScripts/GoogleTagManager.tsx` component: one that runs inside Partytown if the `gtm_debug` query string is not present, and one that runs outside Partytown otherwise. 
 
 Notice that this does not affect performance since the actual GTM script is only downloaded once.
 
@@ -61,17 +47,17 @@ To perform these actions, this component has to be included on every page, which
 
 Some analytics providers do not require their scripts to be executed as soon as the page is rendered. This is a desired behavior because it means the code required to do it doesn't have to be downloaded and parsed as soon as a user enters the page, which is important for performance. That's why we use dynamic imports for all VTEX-specific events.
 
-The code that sends and manages events related to IS and RC is only downloaded when an event is sent. That's done by dynamically and lazily importing their scripts.
+The code that sends and manages events related to IS and RC is only downloaded when an event is sent. That's done by dynamically and lazily importing their scripts. 
 
 :::tip
 Developers can and should use dynamic imports with any other analytics provider integrations added to their store.
 :::
 
 ```tsx
-import type { AnalyticsEvent } from "@faststore/sdk";
-import { useAnalyticsEvent } from "@faststore/sdk";
+import type { AnalyticsEvent } from '@faststore/sdk'
+import { useAnalyticsEvent } from '@faststore/sdk'
 
-import storeConfig from "../../../store.config";
+import storeConfig from '../../../store.config'
 
 export const AnalyticsHandler = () => {
   useAnalyticsEvent((event: AnalyticsEvent) => {
@@ -79,18 +65,18 @@ export const AnalyticsHandler = () => {
 
     import(`./platform/${storeConfig.platform}`).then(
       ({ default: sendEvent }) => {
-        sendEvent(event);
+        sendEvent(event)
       }
-    );
-  });
+    )
+  })
 
-  return null;
-};
+  return null
+}
 ```
 
 ## Page View events
 
-Page View events represent the action of visiting a web page. These events can be automatically tracked by Google Analytics 4, but for limitations imposed by Partytown, collecting this metric does not work automatically. To compensate for that, these events should be fired manually.
+Page View events represent the action of visiting a web page. These events can be automatically tracked by Google Analytics 4, but for limitations imposed by Partytown, collecting this metric does not work automatically. To compensate for that, these events should be fired manually. 
 
 :::caution
 Our official starters do not include the Page View event yet, but we plan to add it soon. Meanwhile, developers can still use the FastStore SDK to manage this event.
@@ -98,7 +84,7 @@ Our official starters do not include the Page View event yet, but we plan to add
 
 ## Partytown proxy
 
-Partytown requires a proxy for some third-party scripts to work. (_Please refer to [Partytown documentation](https://partytown.builder.io/proxying-requests) for more information._) This script isn't necessary for GTM and [`gtag`](https://support.google.com/tagmanager/answer/7582054?hl=en), so we haven't added it yet to our starter, but we'll include it in the future. Meanwhile, you can implement your own proxy and follow Partytown's guide on how to set it up.
+Partytown requires a proxy for some third-party scripts to work. (*Please refer to [Partytown documentation](https://partytown.builder.io/proxying-requests) for more information.*) This script isn't necessary for GTM and [`gtag`](https://support.google.com/tagmanager/answer/7582054?hl=en), so we haven't added it yet to our starter, but we'll include it in the future. Meanwhile, you can implement your own proxy and follow Partytown's guide on how to set it up.
 
 ## Help us
 

--- a/docs/conceptual-guides/analytics-on-official-starters.md
+++ b/docs/conceptual-guides/analytics-on-official-starters.md
@@ -1,7 +1,21 @@
 ---
 title: Analytics on official starters
 description: An overview of our analytics solutions implemented by our official starters and a brief comparison with Store Framework's approach to analytics.
-tags: [ga, gtm, google analytics, google tag manager, google, analytics, sdk, faststore, starters, store framework, AnalyticsHandler, gtmContainerId]
+tags:
+  [
+    ga,
+    gtm,
+    google analytics,
+    google tag manager,
+    google,
+    analytics,
+    sdk,
+    faststore,
+    starters,
+    store framework,
+    AnalyticsHandler,
+    gtmContainerId,
+  ]
 hide_table_of_contents: false
 ---
 
@@ -11,15 +25,15 @@ hide_table_of_contents: false
 We strongly recommend reading the [Analytics on FastStore](/conceptual-guides/analytics-on-faststore) article before diving into this article.
 :::
 
-The recommended way to start building with FastStore is with one of our official starters. They are functional store templates that adhere to web performance and accessibility best practices, also serving as a guideline for all developers building storefronts with FastStore. In this regard, all our official starters have built-in analytics capabilities. 
+The recommended way to start building with FastStore is with one of our official starters. They are functional store templates that adhere to web performance and accessibility best practices, also serving as a guideline for all developers building storefronts with FastStore. In this regard, all our official starters have built-in analytics capabilities.
 
-This article explains how these starters integrate with analytics features and other architectural aspects. 
+This article explains how these starters integrate with analytics features and other architectural aspects.
 
 ## Google Tag Manager
 
-Our official starters include built-in **Google Tag Manager (GTM)** scripts, so developers don't have to worry about manually implementing the GTM script to their website nor configuring debug query strings related to [Partytown](https://www.faststore.dev/how-to-guides/troubleshooting/analytics-and-partytown#google-tag-assistant-is-not-working). 
+Our official starters include built-in **Google Tag Manager (GTM)** scripts, so developers don't have to worry about manually implementing the GTM script to their website nor configuring debug query strings related to [Partytown](/how-to-guides/troubleshooting/analytics-and-partytown#google-tag-assistant-is-not-working).
 
-Our official starters come with two GTM scripts in the `src/components/ThirdPartyScripts/GoogleTagManager.tsx` component: one that runs inside Partytown if the `gtm_debug` query string is not present, and one that runs outside Partytown otherwise. 
+Our official starters come with two GTM scripts in the `src/components/ThirdPartyScripts/GoogleTagManager.tsx` component: one that runs inside Partytown if the `gtm_debug` query string is not present, and one that runs outside Partytown otherwise.
 
 Notice that this does not affect performance since the actual GTM script is only downloaded once.
 
@@ -29,7 +43,7 @@ The **GTM container** being used in your store must be set in the file `store.co
 
 ## Firing events
 
-The [`sendAnalyticsEvent`](https://www.faststore.dev/reference/sdk/analytics/sendAnalyticsEvent) function is used to fire analytics events. All [**GA4 Enhanced Commerce events**](https://developers.google.com/analytics/devguides/collection/ga4/reference/events) are bundled with official starters and are fired in different places in the code, depending on what actions should trigger them.
+The [`sendAnalyticsEvent`](/reference/sdk/analytics/sendAnalyticsEvent) function is used to fire analytics events. All [**GA4 Enhanced Commerce events**](https://developers.google.com/analytics/devguides/collection/ga4/reference/events) are bundled with official starters and are fired in different places in the code, depending on what actions should trigger them.
 
 Notice that each store is responsible for firing the desired analytics events and configuring their corresponding properties. No hook or library can do this automatically, and you must set it manually in your code.
 
@@ -39,7 +53,7 @@ Official starters also include **VTEX Intelligent Search (IS)** events. These ev
 
 ## `AnalyticsHandler` component
 
-Even though the Analytics SDK module does not automatically send events to any analytics provider, our official starters do. That's the `AnalyticsHandler`'s (`src/analytics/index.tsx`) role. The `AnalyticsHandler` component calls the [`useAnalyticsHandler`](https://www.faststore.dev/reference/sdk/analytics/useAnalyticsEvent) hook to intercept analytics events. It's in the `AnalyticsHandler` component that events are sent to the appropriate analytics provider, such as GTM, IS, or VTEX Request Capture (RC).
+Even though the Analytics SDK module does not automatically send events to any analytics provider, our official starters do. That's the `AnalyticsHandler`'s (`src/analytics/index.tsx`) role. The `AnalyticsHandler` component calls the [`useAnalyticsHandler`](/reference/sdk/analytics/useAnalyticsEvent) hook to intercept analytics events. It's in the `AnalyticsHandler` component that events are sent to the appropriate analytics provider, such as GTM, IS, or VTEX Request Capture (RC).
 
 To perform these actions, this component has to be included on every page, which means it usually lives alongside context providers at the root of the application (`gatsby.(browser-server).tsx` in Gatsby and `src/pages/_app.tsx` in NextJS).
 
@@ -47,17 +61,17 @@ To perform these actions, this component has to be included on every page, which
 
 Some analytics providers do not require their scripts to be executed as soon as the page is rendered. This is a desired behavior because it means the code required to do it doesn't have to be downloaded and parsed as soon as a user enters the page, which is important for performance. That's why we use dynamic imports for all VTEX-specific events.
 
-The code that sends and manages events related to IS and RC is only downloaded when an event is sent. That's done by dynamically and lazily importing their scripts. 
+The code that sends and manages events related to IS and RC is only downloaded when an event is sent. That's done by dynamically and lazily importing their scripts.
 
 :::tip
 Developers can and should use dynamic imports with any other analytics provider integrations added to their store.
 :::
 
 ```tsx
-import type { AnalyticsEvent } from '@faststore/sdk'
-import { useAnalyticsEvent } from '@faststore/sdk'
+import type { AnalyticsEvent } from "@faststore/sdk";
+import { useAnalyticsEvent } from "@faststore/sdk";
 
-import storeConfig from '../../../store.config'
+import storeConfig from "../../../store.config";
 
 export const AnalyticsHandler = () => {
   useAnalyticsEvent((event: AnalyticsEvent) => {
@@ -65,18 +79,18 @@ export const AnalyticsHandler = () => {
 
     import(`./platform/${storeConfig.platform}`).then(
       ({ default: sendEvent }) => {
-        sendEvent(event)
+        sendEvent(event);
       }
-    )
-  })
+    );
+  });
 
-  return null
-}
+  return null;
+};
 ```
 
 ## Page View events
 
-Page View events represent the action of visiting a web page. These events can be automatically tracked by Google Analytics 4, but for limitations imposed by Partytown, collecting this metric does not work automatically. To compensate for that, these events should be fired manually. 
+Page View events represent the action of visiting a web page. These events can be automatically tracked by Google Analytics 4, but for limitations imposed by Partytown, collecting this metric does not work automatically. To compensate for that, these events should be fired manually.
 
 :::caution
 Our official starters do not include the Page View event yet, but we plan to add it soon. Meanwhile, developers can still use the FastStore SDK to manage this event.
@@ -84,7 +98,7 @@ Our official starters do not include the Page View event yet, but we plan to add
 
 ## Partytown proxy
 
-Partytown requires a proxy for some third-party scripts to work. (*Please refer to [Partytown documentation](https://partytown.builder.io/proxying-requests) for more information.*) This script isn't necessary for GTM and [`gtag`](https://support.google.com/tagmanager/answer/7582054?hl=en), so we haven't added it yet to our starter, but we'll include it in the future. Meanwhile, you can implement your own proxy and follow Partytown's guide on how to set it up.
+Partytown requires a proxy for some third-party scripts to work. (_Please refer to [Partytown documentation](https://partytown.builder.io/proxying-requests) for more information._) This script isn't necessary for GTM and [`gtag`](https://support.google.com/tagmanager/answer/7582054?hl=en), so we haven't added it yet to our starter, but we'll include it in the future. Meanwhile, you can implement your own proxy and follow Partytown's guide on how to set it up.
 
 ## Help us
 

--- a/docs/conceptual-guides/analytics-store-framework.md
+++ b/docs/conceptual-guides/analytics-store-framework.md
@@ -6,7 +6,7 @@ To handle Google Analytics in **Store Framework**, an **IO app** that implements
 
 ## Autonomy
 
-The FastStore way of approaching analytics gives developers autonomy. They are not tied to any of the choices we've made for starters or FastStore SDK. You can fire your own events, customize them with your own types, and add your properties of choice. This empowers developers and store managers to collect data the way they prefer. We have guides on [How to extend and customize types](https://www.faststore.dev/reference/sdk/analytics/how-to-extend-types) and [How to send custom events](https://www.faststore.dev/reference/sdk/analytics/how-to-send-custom-events).
+The FastStore way of approaching analytics gives developers autonomy. They are not tied to any of the choices we've made for starters or FastStore SDK. You can fire your own events, customize them with your own types, and add your properties of choice. This empowers developers and store managers to collect data the way they prefer. We have guides on [How to extend and customize types](/reference/sdk/analytics/how-to-extend-types) and [How to send custom events](/reference/sdk/analytics/how-to-send-custom-events).
 
 This is quite different from the Store Framework approach. If you need to deviate even a little from the Google Tag Manager **IO app** choices, you may need to detach from the whole app and create your own solution. Still, you'll be limited by the DOM events fired by native apps and blocks and the information they contain. To change that, you would have to detach from the native apps, which defeats the purpose of using Store Framework.
 
@@ -22,6 +22,6 @@ Store Framework gives analytics events for free. You barely have to worry about 
 
 ## Visibility
 
-With Store Framework, it's difficult to know where or when an event is fired. This makes it harder to debug problems and customize events. In FastStore, everything lives in the store repository. Just search for [`sendAnalyticsEvent`](https://www.faststore.dev/reference/sdk/analytics/sendAnalyticsEvent) calls and you'll see where events are being fired and the conditions for that to happen.
+With Store Framework, it's difficult to know where or when an event is fired. This makes it harder to debug problems and customize events. In FastStore, everything lives in the store repository. Just search for [`sendAnalyticsEvent`](/reference/sdk/analytics/sendAnalyticsEvent) calls and you'll see where events are being fired and the conditions for that to happen.
 
 Also, FastStore provides E2E tests for all GA4 Enhanced Ecommerce analytics events it includes, so you can quickly know if something wrong with your analytics implementation. You'll be able to fix these issues before you start to lose valuable user data.

--- a/docs/how-to-guides/cms/vtex-headless-cms/Using onlySettings property in a content type.md
+++ b/docs/how-to-guides/cms/vtex-headless-cms/Using onlySettings property in a content type.md
@@ -1,18 +1,19 @@
 # Using the onlySettings property in a content type
 
-The `onlySetting` property indicates that a [content type](https://www.faststore.dev/tutorials/cms-storecomponents/0#content-types) is meant for settings only.
+The `onlySetting` property indicates that a [content type](/tutorials/cms-storecomponents/0#content-types) is meant for settings only.
 
 You can use this attribute for content types that do not require storefront content, such as SEO pages.
 
-| Image 1  | Image 2  |  
-|---|---|
-| ![with-property](https://user-images.githubusercontent.com/67270558/227936062-02e15860-c6d6-4525-9eed-19c37abfd626.png)  | ![without-property](https://user-images.githubusercontent.com/67270558/227936232-fa8dfab7-2f01-42d1-9f68-b2ab8623a3af.png)  | 
-| Image 1 - Content type with `onlySettings` and with one tab for settings: **SEO**. | Image 2 - Content type without `onlySettings` and with two tabs: **Sections** and **SEO**. | 
+| Image 1                                                                                                                 | Image 2                                                                                                                    |
+| ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| ![with-property](https://user-images.githubusercontent.com/67270558/227936062-02e15860-c6d6-4525-9eed-19c37abfd626.png) | ![without-property](https://user-images.githubusercontent.com/67270558/227936232-fa8dfab7-2f01-42d1-9f68-b2ab8623a3af.png) |
+| Image 1 - Content type with `onlySettings` and with one tab for settings: **SEO**.                                      | Image 2 - Content type without `onlySettings` and with two tabs: **Sections** and **SEO**.                                 |
 
 This property ensures the content type page displays only the available settings without the **Sections** tab. Follow the steps below to use the `onlySettings` property for your desired content type.
 
-## Step-by-step 
-1. Go to the store repository and access  `CMS` > `content-types.json`.
+## Step-by-step
+
+1. Go to the store repository and access `CMS` > `content-types.json`.
 2. Choose a content type and set the `onlySettings` property as `true`. For example:
 
 ```json

--- a/docs/how-to-guides/cms/vtex-headless-cms/Using onlySettings property in a content type.md
+++ b/docs/how-to-guides/cms/vtex-headless-cms/Using onlySettings property in a content type.md
@@ -4,16 +4,15 @@ The `onlySetting` property indicates that a [content type](/tutorials/cms-storec
 
 You can use this attribute for content types that do not require storefront content, such as SEO pages.
 
-| Image 1                                                                                                                 | Image 2                                                                                                                    |
-| ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| ![with-property](https://user-images.githubusercontent.com/67270558/227936062-02e15860-c6d6-4525-9eed-19c37abfd626.png) | ![without-property](https://user-images.githubusercontent.com/67270558/227936232-fa8dfab7-2f01-42d1-9f68-b2ab8623a3af.png) |
-| Image 1 - Content type with `onlySettings` and with one tab for settings: **SEO**.                                      | Image 2 - Content type without `onlySettings` and with two tabs: **Sections** and **SEO**.                                 |
+| Image 1  | Image 2  |  
+|---|---|
+| ![with-property](https://user-images.githubusercontent.com/67270558/227936062-02e15860-c6d6-4525-9eed-19c37abfd626.png)  | ![without-property](https://user-images.githubusercontent.com/67270558/227936232-fa8dfab7-2f01-42d1-9f68-b2ab8623a3af.png)  | 
+| Image 1 - Content type with `onlySettings` and with one tab for settings: **SEO**. | Image 2 - Content type without `onlySettings` and with two tabs: **Sections** and **SEO**. | 
 
 This property ensures the content type page displays only the available settings without the **Sections** tab. Follow the steps below to use the `onlySettings` property for your desired content type.
 
-## Step-by-step
-
-1. Go to the store repository and access `CMS` > `content-types.json`.
+## Step-by-step 
+1. Go to the store repository and access  `CMS` > `content-types.json`.
 2. Choose a content type and set the `onlySettings` property as `true`. For example:
 
 ```json

--- a/docs/how-to-guides/faststore-api/creating-resolvers.md
+++ b/docs/how-to-guides/faststore-api/creating-resolvers.md
@@ -1,6 +1,6 @@
 # Creating inline resolvers
 
-If you need to [extend the FastStore API schema](https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api) for your project or you wish to use an ecommerce platform that is not natively supported, you must create the corresponding inline resolvers.
+If you need to [extend the FastStore API schema](/how-to-guides/faststore-api/extending-the-faststore-api) for your project or you wish to use an ecommerce platform that is not natively supported, you must create the corresponding inline resolvers.
 
 This means you are going to write resolvers for the API schema in your project or use an external library.
 

--- a/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
+++ b/docs/how-to-guides/faststore-api/explore-the-faststore-api.mdx
@@ -2,8 +2,8 @@
 sidebar_position: 1
 ---
 
-import Tabs from '@theme/Tabs'
-import TabItem from '@theme/TabItem'
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # Using a GraphQL IDE to explore the FastStore API
 
@@ -13,7 +13,7 @@ There are different GraphQL IDEs you can use. In this tutorial, you will learn h
 
 ## Before you start
 
-Whatever GraphQL IDE you choose to use, the important thing to know is that when you run your project locally, you should have access to a local API endpoint. If you created your store from one of the official [FastStore starters](https://www.faststore.dev/starters), it most likely already supports the local endpoint. To know for sure if your project's local API is available, look for the following files:
+Whatever GraphQL IDE you choose to use, the important thing to know is that when you run your project locally, you should have access to a local API endpoint. If you created your store from one of the official [FastStore starters](/starters), it most likely already supports the local endpoint. To know for sure if your project's local API is available, look for the following files:
 
 - [nextjs.store](https://github.com/vtex-sites/nextjs.store) based projects: `src/pages/api/graphql.ts`.
 - [gatsby.store](https://github.com/vtex-sites/gatsby.store) based projects (using Gatsby v4): `src/api/graphql.ts`.

--- a/docs/how-to-guides/faststore-api/fetching-api-data.mdx
+++ b/docs/how-to-guides/faststore-api/fetching-api-data.mdx
@@ -1,12 +1,12 @@
-import Tabs from '@theme/Tabs'
-import TabItem from '@theme/TabItem'
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # Fetching API data on the storefront
 
 You can build and customize GraphQL queries to display ecommerce data on your storefront, such as products and shopping cart information. In this guide, you will find the basic concepts and steps to implement this in your FastStore project.
 
 :::caution
-When building your storefront with FastStore, you must not send requests to APIs other than the FastStore API. If you need to access other data not available in the [native FastStore API schema](https://www.faststore.dev/reference/api/queries), you must do this by [extending the GraphQL schema](https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api). Otherwise, site performance may be compromised and lead to `504` timeout errors.
+When building your storefront with FastStore, you must not send requests to APIs other than the FastStore API. If you need to access other data not available in the [native FastStore API schema](/reference/api/queries), you must do this by [extending the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api). Otherwise, site performance may be compromised and lead to `504` timeout errors.
 :::
 
 ## Before you start
@@ -34,20 +34,19 @@ This also means that you must be mindful of the data brought into your query by 
 
 #### Do not send requests to other APIs
 
-If you need data that is not available on the native [FastStore GraphQL schema](https://www.faststore.dev/reference/api/objects), check the [root object](/reference/api/root-object-fields).
+If you need data that is not available on the native [FastStore GraphQL schema](/reference/api/objects), check the [root object](/reference/api/root-object-fields).
 
-The [GraphQL root object](https://graphql.org/learn/execution/#root-fields-resolvers) represents the top-level object returned to a query. You can see what data is available in the root object by adding logs or [using a GraphQL IDE](https://www.faststore.dev/how-to-guides/faststore-api/explore-the-faststore-api).
+The [GraphQL root object](https://graphql.org/learn/execution/#root-fields-resolvers) represents the top-level object returned to a query. You can see what data is available in the root object by adding logs or [using a GraphQL IDE](/how-to-guides/faststore-api/explore-the-faststore-api).
 
-If the root object also lacks the information you need, you must [extend the FastStore GraphQL schema](https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api) instead of adding other requests to your page.
+If the root object also lacks the information you need, you must [extend the FastStore GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api) instead of adding other requests to your page.
 
 #### Avoid custom API Routes
 
-We do not recomend using Next.js [API Routes](https://nextjs.org/docs/api-routes/introduction) other than the ones already built in the [FastStore starters](https://www.faststore.dev/starters).
+We do not recomend using Next.js [API Routes](https://nextjs.org/docs/api-routes/introduction) other than the ones already built in the [FastStore starters](/starters).
 
 If you do use this type of function, you must be mindful to always check which ones are actually running and remove the ones that are not.
 
-To see what API Routes are running in your project, you can run the command `yarn build` at the root of your project and check the log. Then, check the directory `src/pages/api` of your project and remove functions that are not running or are not included in the [starter](https://www.faststore.dev/starters) you used.
-
+To see what API Routes are running in your project, you can run the command `yarn build` at the root of your project and check the log. Then, check the directory `src/pages/api` of your project and remove functions that are not running or are not included in the [starter](/starters) you used.
 
 ## Fetching ecommerce data
 
@@ -61,7 +60,7 @@ Below you can see more details about each step along with code examples.
 
 ### 1. Building a query
 
-First, you need to know what API data you want to use on your page and how to structure a GraphQL query to get it. It is a good idea to check the [FastStore API reference on queries](https://www.faststore.dev/reference/api/queries). You can also [use a GraphQL IDE to build and test queries](https://www.faststore.dev/how-to-guides/faststore-api/explore-the-faststore-api) to make sure it works as expected.
+First, you need to know what API data you want to use on your page and how to structure a GraphQL query to get it. It is a good idea to check the [FastStore API reference on queries](/reference/api/queries). You can also [use a GraphQL IDE to build and test queries](/how-to-guides/faststore-api/explore-the-faststore-api) to make sure it works as expected.
 
 Once you have your query structure, you can pass that as a variable on your code by using the `gql` tag, like in the example below.
 
@@ -342,11 +341,11 @@ function Page({ product }: Props) {
 After completing the steps described above, your code should look like the example below.
 
 :::info
-It is also a good idea to see how data fetching is implemented in pages from [FastStore starters](https://www.faststore.dev/starters), such as:
+It is also a good idea to see how data fetching is implemented in pages from [FastStore starters](/starters), such as:
 
 - [Next.js store product page](https://github.com/vtex-sites/nextjs.store/blob/main/src/pages/%5Bslug%5D/p.tsx)
 - [Gatsby store product page](https://github.com/vtex-sites/gatsby.store/blob/main/src/pages/%5Bslug%5D/p.tsx)
-:::
+  :::
 
 ```javascript
 import { gql } from '@faststore/graphql-utils'

--- a/docs/reference/api/faststore-api.md
+++ b/docs/reference/api/faststore-api.md
@@ -9,7 +9,7 @@ import GraphQLExplorer from '@site/src/components/GraphQLExplorer/GraphQLExplore
 
 **FastStore API** is an interface between your ecommerce platform and your store's frontend. It uses **[GraphQL](https://graphql.org/)**, a query language for APIs and a runtime for fulfilling queries, in order to expose structured data from everyday ecommerce tasks to frontend components.
 
-The FastStore API allows you to get all information you need for a given page. You can customize your query to get exactly the data you need and even [extend the GraphQL schema](https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api) to fetch data not natively available. Following these best practices helps to maintain your site's performance at optimal levels.  
+The FastStore API allows you to get all information you need for a given page. You can customize your query to get exactly the data you need and even [extend the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api) to fetch data not natively available. Following these best practices helps to maintain your site's performance at optimal levels.
 
 With the FastStore API, you can:
 
@@ -21,7 +21,7 @@ With the FastStore API, you can:
 Also, thanks to a type-safe **GraphQL** protocol, the FastStore API allows developers to fetch only the strongly typed data needed for building robust and responsive solutions. In practice, developers can source the FastStore API to the [**Next.js**](https://nextjs.org/) or [**Gatsby**](https://www.gatsbyjs.com/) data layers and consume it on frontend components to create stores that use the [**Jamstack**](https://jamstack.org/) architecture.
 
 :::caution
-When building your storefront with FastStore, you must not send requests to APIs other than the FastStore API. If you need to access other data not available in the [native FastStore API schema](https://www.faststore.dev/reference/api/queries), you must do this by [extending the GraphQL schema](https://www.faststore.dev/how-to-guides/faststore-api/extending-the-faststore-api). Otherwise, site performance may be compromised and lead to `504` timeout errors. 
+When building your storefront with FastStore, you must not send requests to APIs other than the FastStore API. If you need to access other data not available in the [native FastStore API schema](/reference/api/queries), you must do this by [extending the GraphQL schema](/how-to-guides/faststore-api/extending-the-faststore-api). Otherwise, site performance may be compromised and lead to `504` timeout errors.
 :::
 
 ![FastStore API usage architecture](https://vtexhelp.vtexassets.com/assets/docs/src/faststoreAPI2___58c4a9c4d23539900ef8b1cce9769288.png)
@@ -34,11 +34,11 @@ To learn more about GraphQL and its main concepts, visit the official [GraphQL w
 
 FastStore API is based on [**Schema.org**](https://schema.org/) and inspired by **clean architecture**.
 
-### Improved brand findability 
+### Improved brand findability
 
 FastStore API extends and simplifies [**Schema.org**](https://schema.org/), a set of agreed definitions for implementing structured data developed by Google, Microsoft, Yahoo, and Yandex.
 
-The Schema markup aids search engines in understanding and displaying your content in a relevant way. It may improve your brand's findability by leading your website to a higher ranking in search results and, as a result, to more clicks and interactions with your store's website. 
+The Schema markup aids search engines in understanding and displaying your content in a relevant way. It may improve your brand's findability by leading your website to a higher ranking in search results and, as a result, to more clicks and interactions with your store's website.
 
 ### Flexible backend for frontend architecture
 

--- a/docs/reference/sdk/Session.md
+++ b/docs/reference/sdk/Session.md
@@ -43,29 +43,29 @@ Below you can see details of the session data managed by the session SDK module.
 The session SDK module exports a `createSessionStore` function and `Session` type, which you can import like this:
 
 ```ts
-import { createSessionStore } from '@faststore/sdk'
-import type { Session } from '@faststore/sdk'
+import { createSessionStore } from "@faststore/sdk";
+import type { Session } from "@faststore/sdk";
 ```
 
-See in the example below how these are used in the [Next.js store](https://github.com/vtex-sites/nextjs.store) to export other functions that update session information and validate them with the [FastStore API](https://www.faststore.dev/reference/api/faststore-api).
+See in the example below how these are used in the [Next.js store](https://github.com/vtex-sites/nextjs.store) to export other functions that update session information and validate them with the [FastStore API](/reference/api/faststore-api).
 
 ```ts
 //src/sdk/session/index.ts
 
-import { gql } from '@faststore/graphql-utils'
-import { createSessionStore } from '@faststore/sdk'
-import { useMemo } from 'react'
-import type { Session } from '@faststore/sdk'
+import { gql } from "@faststore/graphql-utils";
+import { createSessionStore } from "@faststore/sdk";
+import { useMemo } from "react";
+import type { Session } from "@faststore/sdk";
 
-import storeConfig from 'store.config'
+import storeConfig from "store.config";
 
-import { cartStore } from '../cart'
-import { request } from '../graphql/request'
-import { createValidationStore, useStore } from '../useStore'
+import { cartStore } from "../cart";
+import { request } from "../graphql/request";
+import { createValidationStore, useStore } from "../useStore";
 import type {
   ValidateSessionMutation,
   ValidateSessionMutationVariables,
-} from '../../../@generated/graphql/index'
+} from "../../../@generated/graphql/index";
 
 export const mutation = gql`
   mutation ValidateSession($session: IStoreSession!, $search: String!) {
@@ -86,34 +86,34 @@ export const mutation = gql`
       }
     }
   }
-`
+`;
 
 export const validateSession = async (session: Session) => {
   const data = await request<
     ValidateSessionMutation,
     ValidateSessionMutationVariables
-  >(mutation, { session, search: window.location.search })
+  >(mutation, { session, search: window.location.search });
 
-  return data.validateSession
-}
+  return data.validateSession;
+};
 
-const [validationStore, onValidate] = createValidationStore(validateSession)
+const [validationStore, onValidate] = createValidationStore(validateSession);
 
-const defaultStore = createSessionStore(storeConfig.session, onValidate)
+const defaultStore = createSessionStore(storeConfig.session, onValidate);
 
 export const sessionStore = {
   ...defaultStore,
   set: (val: Session) => {
-    defaultStore.set(val)
+    defaultStore.set(val);
 
     // Trigger cart revalidation when session changes
-    cartStore.set(cartStore.read())
+    cartStore.set(cartStore.read());
   },
-}
+};
 
 export const useSession = () => {
-  const session = useStore(sessionStore)
-  const isValidating = useStore(validationStore)
+  const session = useStore(sessionStore);
+  const isValidating = useStore(validationStore);
 
   return useMemo(
     () => ({
@@ -121,56 +121,56 @@ export const useSession = () => {
       isValidating,
     }),
     [isValidating, session]
-  )
-}
+  );
+};
 ```
 
-Because of this, if you use one of the [Base Store starters](https://www.faststore.dev/starters/base), you have access to `sessionStore`, `useSession` and `validateSession`.
+Because of this, if you use one of the [Base Store starters](/starters/base), you have access to `sessionStore`, `useSession` and `validateSession`.
 
 See the example below to learn more about how these are used in the [Next.js store](https://github.com/vtex-sites/nextjs.store) to update session data according to shopper regionalization input.
 
 ```ts
 //src/components/regionalization/RegionalizationInput/RegionalizationInput.tsx
 
-import { useRef, useState } from 'react'
+import { useRef, useState } from "react";
 
-import InputText from 'src/components/ui/InputText'
-import { sessionStore, useSession, validateSession } from 'src/sdk/session'
+import InputText from "src/components/ui/InputText";
+import { sessionStore, useSession, validateSession } from "src/sdk/session";
 
 interface Props {
-  closeModal: () => void
+  closeModal: () => void;
 }
 
 function RegionInput({ closeModal }: Props) {
-  const inputRef = useRef<HTMLInputElement>(null)
-  const { isValidating, ...session } = useSession()
-  const [errorMessage, setErrorMessage] = useState<string>('')
-  const [input, setInput] = useState<string>('')
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { isValidating, ...session } = useSession();
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [input, setInput] = useState<string>("");
 
   const handleSubmit = async () => {
-    const postalCode = inputRef.current?.value
+    const postalCode = inputRef.current?.value;
 
-    if (typeof postalCode !== 'string') {
-      return
+    if (typeof postalCode !== "string") {
+      return;
     }
 
-    setErrorMessage('')
+    setErrorMessage("");
 
     try {
       const newSession = {
         ...session,
         postalCode,
-      }
+      };
 
-      const validatedSession = await validateSession(newSession)
+      const validatedSession = await validateSession(newSession);
 
-      sessionStore.set(validatedSession ?? newSession)
+      sessionStore.set(validatedSession ?? newSession);
 
-      closeModal()
+      closeModal();
     } catch (error) {
-      setErrorMessage('You entered an invalid Postal Code')
+      setErrorMessage("You entered an invalid Postal Code");
     }
-  }
+  };
 
   return (
     <div className="regionalization-input">
@@ -182,15 +182,15 @@ function RegionInput({ closeModal }: Props) {
         actionable
         value={input}
         onInput={(e) => {
-          errorMessage !== '' && setErrorMessage('')
-          setInput(e.currentTarget.value)
+          errorMessage !== "" && setErrorMessage("");
+          setInput(e.currentTarget.value);
         }}
         onSubmit={handleSubmit}
-        onClear={() => setInput('')}
+        onClear={() => setInput("")}
       />
     </div>
-  )
+  );
 }
 
-export default RegionInput
+export default RegionInput;
 ```

--- a/docs/reference/sdk/Session.md
+++ b/docs/reference/sdk/Session.md
@@ -43,8 +43,8 @@ Below you can see details of the session data managed by the session SDK module.
 The session SDK module exports a `createSessionStore` function and `Session` type, which you can import like this:
 
 ```ts
-import { createSessionStore } from "@faststore/sdk";
-import type { Session } from "@faststore/sdk";
+import { createSessionStore } from '@faststore/sdk'
+import type { Session } from '@faststore/sdk'
 ```
 
 See in the example below how these are used in the [Next.js store](https://github.com/vtex-sites/nextjs.store) to export other functions that update session information and validate them with the [FastStore API](/reference/api/faststore-api).
@@ -52,20 +52,20 @@ See in the example below how these are used in the [Next.js store](https://githu
 ```ts
 //src/sdk/session/index.ts
 
-import { gql } from "@faststore/graphql-utils";
-import { createSessionStore } from "@faststore/sdk";
-import { useMemo } from "react";
-import type { Session } from "@faststore/sdk";
+import { gql } from '@faststore/graphql-utils'
+import { createSessionStore } from '@faststore/sdk'
+import { useMemo } from 'react'
+import type { Session } from '@faststore/sdk'
 
-import storeConfig from "store.config";
+import storeConfig from 'store.config'
 
-import { cartStore } from "../cart";
-import { request } from "../graphql/request";
-import { createValidationStore, useStore } from "../useStore";
+import { cartStore } from '../cart'
+import { request } from '../graphql/request'
+import { createValidationStore, useStore } from '../useStore'
 import type {
   ValidateSessionMutation,
   ValidateSessionMutationVariables,
-} from "../../../@generated/graphql/index";
+} from '../../../@generated/graphql/index'
 
 export const mutation = gql`
   mutation ValidateSession($session: IStoreSession!, $search: String!) {
@@ -86,34 +86,34 @@ export const mutation = gql`
       }
     }
   }
-`;
+`
 
 export const validateSession = async (session: Session) => {
   const data = await request<
     ValidateSessionMutation,
     ValidateSessionMutationVariables
-  >(mutation, { session, search: window.location.search });
+  >(mutation, { session, search: window.location.search })
 
-  return data.validateSession;
-};
+  return data.validateSession
+}
 
-const [validationStore, onValidate] = createValidationStore(validateSession);
+const [validationStore, onValidate] = createValidationStore(validateSession)
 
-const defaultStore = createSessionStore(storeConfig.session, onValidate);
+const defaultStore = createSessionStore(storeConfig.session, onValidate)
 
 export const sessionStore = {
   ...defaultStore,
   set: (val: Session) => {
-    defaultStore.set(val);
+    defaultStore.set(val)
 
     // Trigger cart revalidation when session changes
-    cartStore.set(cartStore.read());
+    cartStore.set(cartStore.read())
   },
-};
+}
 
 export const useSession = () => {
-  const session = useStore(sessionStore);
-  const isValidating = useStore(validationStore);
+  const session = useStore(sessionStore)
+  const isValidating = useStore(validationStore)
 
   return useMemo(
     () => ({
@@ -121,8 +121,8 @@ export const useSession = () => {
       isValidating,
     }),
     [isValidating, session]
-  );
-};
+  )
+}
 ```
 
 Because of this, if you use one of the [Base Store starters](/starters/base), you have access to `sessionStore`, `useSession` and `validateSession`.
@@ -132,45 +132,45 @@ See the example below to learn more about how these are used in the [Next.js sto
 ```ts
 //src/components/regionalization/RegionalizationInput/RegionalizationInput.tsx
 
-import { useRef, useState } from "react";
+import { useRef, useState } from 'react'
 
-import InputText from "src/components/ui/InputText";
-import { sessionStore, useSession, validateSession } from "src/sdk/session";
+import InputText from 'src/components/ui/InputText'
+import { sessionStore, useSession, validateSession } from 'src/sdk/session'
 
 interface Props {
-  closeModal: () => void;
+  closeModal: () => void
 }
 
 function RegionInput({ closeModal }: Props) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const { isValidating, ...session } = useSession();
-  const [errorMessage, setErrorMessage] = useState<string>("");
-  const [input, setInput] = useState<string>("");
+  const inputRef = useRef<HTMLInputElement>(null)
+  const { isValidating, ...session } = useSession()
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const [input, setInput] = useState<string>('')
 
   const handleSubmit = async () => {
-    const postalCode = inputRef.current?.value;
+    const postalCode = inputRef.current?.value
 
-    if (typeof postalCode !== "string") {
-      return;
+    if (typeof postalCode !== 'string') {
+      return
     }
 
-    setErrorMessage("");
+    setErrorMessage('')
 
     try {
       const newSession = {
         ...session,
         postalCode,
-      };
+      }
 
-      const validatedSession = await validateSession(newSession);
+      const validatedSession = await validateSession(newSession)
 
-      sessionStore.set(validatedSession ?? newSession);
+      sessionStore.set(validatedSession ?? newSession)
 
-      closeModal();
+      closeModal()
     } catch (error) {
-      setErrorMessage("You entered an invalid Postal Code");
+      setErrorMessage('You entered an invalid Postal Code')
     }
-  };
+  }
 
   return (
     <div className="regionalization-input">
@@ -182,15 +182,15 @@ function RegionInput({ closeModal }: Props) {
         actionable
         value={input}
         onInput={(e) => {
-          errorMessage !== "" && setErrorMessage("");
-          setInput(e.currentTarget.value);
+          errorMessage !== '' && setErrorMessage('')
+          setInput(e.currentTarget.value)
         }}
         onSubmit={handleSubmit}
-        onClear={() => setInput("")}
+        onClear={() => setInput('')}
       />
     </div>
-  );
+  )
 }
 
-export default RegionInput;
+export default RegionInput
 ```


### PR DESCRIPTION
- Using relative path to avoid the 404 error. (Pages was pointing to https://www.faststore.dev/ instead of https://v1.faststore.dev/)