### PR TITLE
Docs: Fixing broken links

### DIFF
--- a/blog/2023-04-03-cms.md
+++ b/blog/2023-04-03-cms.md
@@ -23,4 +23,4 @@ Now, the `onlySettings` property allows the creation of content types meant for 
 The change enables the creation of setting-only content types that do not require storefront content, and simplifies interface navigation by displaying only one tab for the page configuration.
 
 ## What needs to be done?
-To add the property to your store, please follow the instructions in [Using `onlySettings` property in a content type](https://www.faststore.dev/how-to-guides/cms/vtex-headless-cms/Using%20onlySettings%20property%20in%20a%20content%20type).
+To add the property to your store, please follow the instructions in [Using `onlySettings` property in a content type](https://v1.faststore.dev/how-to-guides/cms/vtex-headless-cms/Using%20onlySettings%20property%20in%20a%20content%20type).

--- a/blog/2023-04-06-cms.md
+++ b/blog/2023-04-06-cms.md
@@ -19,4 +19,4 @@ With the `isSingleton` property, you can keep consistency across the content typ
 The change enables consistency in the content of a page. The `isSingleton` property prevents the creation of multiple pages of the same content type and ensures updates to the page layout are reflected in all requests.
 
 ## What needs to be done?
-For more information, please refer to the [Using `isSingleton` property in a content type](https://www.faststore.dev/how-to-guides/cms/vtex-headless-cms/Using%20isSingleton%20property%20in%20a%20contenty%20type) documentation.
+For more information, please refer to the [Using `isSingleton` property in a content type](https://v1.faststore.dev/how-to-guides/cms/vtex-headless-cms/Using%20isSingleton%20property%20in%20a%20contenty%20type) documentation.


### PR DESCRIPTION
Due to the FastStore docs new portal (faststore.dev), many links from this repo need to be fixed. This PR intends to fix these links. This PR will also help map docs that should be in faststore.dev.