### PR TITLE
fix(setting-up-secrets.md): private environment file

### DIFF
--- a/docs/how-to-guides/webops/security/setting-up-secrets.md
+++ b/docs/how-to-guides/webops/security/setting-up-secrets.md
@@ -42,13 +42,14 @@ Before proceeding any further with this guide, make sure you have:
 ### Step 2 - Setting up your VTEX account to accept secrets
 
 1. Change the current directory to your FastStore’s repository root.
-2. In the root of your project, create the `vtex.env` file and keep it empty.
-
-   - Skip this step if your project already has the `vtex.env` file.
+2. In the root of your project, create an empty file named `{fileName}.env` to store private environment variables.
 
    ```sh
-   touch vtex.env
+   touch {fileName}.env
    ```
+   :::caution
+   ️Replace `{fileName}` with the desired name for your environment file, such as `private.env`.
+   :::
 
 3. Now, run the following command to configure your VTEX account and your FastStore project to be able to save Secrets.
 

--- a/docs/how-to-guides/webops/security/setting-up-secrets.md
+++ b/docs/how-to-guides/webops/security/setting-up-secrets.md
@@ -42,14 +42,11 @@ Before proceeding any further with this guide, make sure you have:
 ### Step 2 - Setting up your VTEX account to accept secrets
 
 1. Change the current directory to your FastStore’s repository root.
-2. In the root of your project, create an empty file named `{fileName}.env` to store private environment variables.
+2. In the root of your project, create an empty file named `.env` to store private environment variables.
 
    ```sh
-   touch {fileName}.env
+   touch .env
    ```
-   :::caution
-   ️Replace `{fileName}` with the desired name for your environment file, such as `private.env`.
-   :::
 
 3. Now, run the following command to configure your VTEX account and your FastStore project to be able to save Secrets.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,7 +37,7 @@ module.exports = {
     announcementBar: {
       id: 'new_portal',
       content: 
-      `🚧 <span style="color:var(--ifm-color-rebel-pink); background-color:var(--ifm-tag-highlight); padding:0.5em; margin:0.3em; border-radius:5px; font-weight: bold" > FastStore 1.0 is no longer receiving updates. Please visit the Developer Portal for <a style="color:var(--ifm-link-color)" href="https://developers.vtex.com/docs/guides/faststore/docs-what-is-faststore"> FastStore 2.0 content</a>.</span>`,
+      '📢 <span style="color:var(--ifm-color-rebel-pink); background-color:var(--ifm-tag-highlight); padding:0.5em; margin:0.3em; border-radius:5px; font-weight: bold" > FastStore 1.0 is no longer receiving updates. For the FastStore latest version, visit the <a style="color:var(--ifm-link-color)" href="https://developers.vtex.com/docs/guides/faststore/docs-what-is-faststore">Developer Portal</a>.</span>',
       textColor: 'var(--ifm-color-details)',
       backgroundColor: 'var(--ifm-tag-highlight)',
       isCloseable: false,


### PR DESCRIPTION
Changing the recommendation to store private variables from the `vtex.env` file to a `.env` file that the user will create only to store private variables. Related to #inc-1072.

Reference: https://github.com/vtexdocs/dev-portal-content/pull/1337